### PR TITLE
Add CORS Middleware to EHR FHIR endpoint

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -82,6 +82,13 @@ services:
       PATH_WHITELIST: /fhir/metadata
     labels:
       - "traefik.enable=true"
+
+      # add CORS middleware, configured to return `Access-Control-Allow-Origin: *`
+      # NB accessControlAllowOrigin is deprecated, but not noted in docs
+      # https://github.com/traefik/traefik/issues/8796
+      - "traefik.http.middlewares.fhirwall-${COMPOSE_PROJECT_NAME}-cors.headers.accessControlAllowOriginList=*"
+      - "traefik.http.routers.fhirwall-${COMPOSE_PROJECT_NAME}.middlewares=fhirwall-${COMPOSE_PROJECT_NAME}-cors"
+
       - "traefik.http.routers.fhirwall-${COMPOSE_PROJECT_NAME}.rule=Host(`fhirwall.${BASE_DOMAIN:-localtest.me}`)"
       - "traefik.http.routers.fhirwall-${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
       - "traefik.http.routers.fhirwall-${COMPOSE_PROJECT_NAME}.tls=true"


### PR DESCRIPTION
- Use traefik `headers` middleware to add CORS headers needed by SoF frontend client